### PR TITLE
Use built-in os library to set default filepath

### DIFF
--- a/GPSTracker.py
+++ b/GPSTracker.py
@@ -1,48 +1,52 @@
 #!/usr/bin/env python
 
 import json
+import os
 import urllib
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from textwrap import dedent
 
-#path to json library with device ID and friendly name
-with open("IDdict.json") as f:
-    ID2NAME = json.load(f)
+script_dir = os.path.dirname(__file__)
+
+# path to json library with device ID and friendly name
+with open(os.path.join(script_dir, 'IDdict.json')) as f:
+    ID2NAME=json.load(f)
 
 class OsmAndHandler(BaseHTTPRequestHandler):
     def __init__(self, devices, *args):
-        self.devices = devices
+        self.devices=devices
         BaseHTTPRequestHandler.__init__(self, *args)
 
     def do_GET(self):
         if not self.path.startswith("/id"):
             return
 
-        data = urllib.parse.parse_qs(self.path)
-        device_ip = self.client_address[0]
-        device_id = (
-            ID2NAME.get(data.get("/id", [None])[0]) or data.get("/id", [device_ip])[0]
+        data=urllib.parse.parse_qs(self.path)
+        device_ip=self.client_address[0]
+        device_id=(
+            ID2NAME.get(data.get("/id", [None])[0]
+                        ) or data.get("/id", [device_ip])[0]
         )
-        device = {
+        device={
             device_id: {
-                "lat": data["lat"][0],  #latitude
-                "lon": data["lon"][0],  #longitude
-                "alt": data["alt"][0],  #altitude
+                "lat": data["lat"][0],  # latitude
+                "lon": data["lon"][0],  # longitude
+                "alt": data["alt"][0],  # altitude
                             }
         }
         self.devices.update(device)
 
         # Updated location, now write KML with ALL objects
         # Test script for browser: http://localhost:9000/id=111&lat=30&lon=-95&alt=0
-        with open("tracker.kml", "w") as f:
-            header = """\
+        with open(os.path.join(script_dir, "tracker.kml"), "w") as f:
+            header="""\
             <?xml version="1.0" encoding="UTF-8"?>
             <kml xmlns="http://www.opengis.net/kml/2.2" xmlns:kml="http://www.opengis.net/kml/2.2">
             <Document>
                 <Folder>
                     <name>GPS Tracker</name>
             """
-            entry = """\
+            entry="""\
                     <Placemark>
                         <name>{device}</name>
                         <Point>
@@ -51,7 +55,7 @@ class OsmAndHandler(BaseHTTPRequestHandler):
                         </Point>
                     </Placemark>
             """
-            footer = """\
+            footer="""\
                 </Folder>
             </Document>
             </kml>
@@ -59,10 +63,10 @@ class OsmAndHandler(BaseHTTPRequestHandler):
 
             f.write(dedent(header))
             for device in self.devices:
-                lat = self.devices[device]["lat"]
-                lon = self.devices[device]["lon"]
-                alt = self.devices[device]["alt"]
-                lines = dedent(
+                lat=self.devices[device]["lat"]
+                lon=self.devices[device]["lon"]
+                alt=self.devices[device]["alt"]
+                lines=dedent(
                     (entry.format(device=device, lat=lat, lon=lon, alt=alt))
                 ).splitlines()
                 for line in lines:
@@ -77,7 +81,7 @@ class OsmAndHandler(BaseHTTPRequestHandler):
         self.end_headers()
 
         # Send message back to client
-        message = "Location received!"
+        message="Location received!"
         # Write content as utf-8 data
         self.wfile.write(bytes(message, "utf8"))
 
@@ -85,15 +89,14 @@ def osmand2kml_server(devices):
     def handler(*args):
         OsmAndHandler(devices, *args)
 
-    server = HTTPServer(("localhost", 9000), handler)
+    server=HTTPServer(("localhost", 9000), handler)
     print("Server is running!")
     server.serve_forever()
 
 def main():
-    devices = {}
+    devices={}
     osmand2kml_server(devices)
 
 if __name__ == "__main__":
     print("Starting server...")
     main()
-    

--- a/README.md
+++ b/README.md
@@ -6,12 +6,20 @@ viewing in Google Earth.
 
 Setup:
 1. Extract files to same directory.
-2. Optional: Set filepath in GPSTracker.py for IDdict.json (Line 9) and for tracker.kml (Line 38). Default location for files is script project folder.
+2. Optional: Set filepath in GPSTracker.py for IDdict.json (Line 9) and for tracker.kml (Line 38).
+
+* Default location for files is script project folder.
+
 3. Save and run GPSTracker.py - Terminal should echo "Starting server..." and "Server is running!"
-With terminal pointed to project folder with the script:
+
+* With terminal pointed to project folder with the script:
+
 '''python GPSTracker.py'''
+
 4. Open browser, and enter HTTP Request to test server.
+
 ```http://localhost:9000/id=111&lat=30&lon=-95&alt=0```
+
 5. Open Google Earth and add in a Network Link (Add -> Network Link).
 6. Set the file pathway for tracker.kml.
 7. Set Refresh to Time-Based Periodically and 5 secs.

--- a/README.md
+++ b/README.md
@@ -6,16 +6,17 @@ viewing in Google Earth.
 
 Setup:
 1. Extract files to same directory.
-2. Open GPSTracker.py to set up file pathways.
-3. Will need to set pathway for IDdict.json (Line 9) and for tracker.kml (Line 38).
-4. Copy test script for browser to clipboard (Line 37).
-5. Save and run GPSTracker.py - Should return "Starting server..." and "Server is running!"
-6. Open browser (see notes below) and enter the test script.
-7. Open Google Earth and add in a Network Link (Add -> Network Link).
-8. Set the file pathway for tracker.kml.
-9. Set Refresh to Time-Based Periodically and 5 secs.
-10. Make a change to the browser script name, latitude, longitude, or altitude and enter.
-11. Observe the placemark change in Google Earth after 5 seconds.
+2. Optional: Set filepath in GPSTracker.py for IDdict.json (Line 9) and for tracker.kml (Line 38). Default location for files is script project folder.
+3. Save and run GPSTracker.py - Terminal should echo "Starting server..." and "Server is running!"
+With terminal pointed to project folder with the script:
+'''python GPSTracker.py'''
+4. Open browser, and enter HTTP Request to test server.
+```http://localhost:9000/id=111&lat=30&lon=-95&alt=0```
+5. Open Google Earth and add in a Network Link (Add -> Network Link).
+6. Set the file pathway for tracker.kml.
+7. Set Refresh to Time-Based Periodically and 5 secs.
+8. Make a change to the browser HTTP request name, latitude, longitude, or altitude and enter.
+9. Observe the placemark change in Google Earth after 5 seconds.
 
 Notes:
 Tested using Chrome and Firefox.


### PR DESCRIPTION
I used the built-in Python library 'os' to pull the main script filepath for 'GPSTracker.py'.
This absolute path is joined using os.path.join to the filenames for IDdict.json and tracker.kml.
This reduces the amount of setup required for new users. 

Adjusted documentation to reflect these changes.